### PR TITLE
Don't set repository.

### DIFF
--- a/mc/BaselineOfZeroConf.package/BaselineOfZeroConf.class/instance/baseline..st
+++ b/mc/BaselineOfZeroConf.package/BaselineOfZeroConf.class/instance/baseline..st
@@ -1,5 +1,4 @@
 accessing
-"protocol: accessing"
 baseline: spec 
 	<baseline>
 	

--- a/mc/BaselineOfZeroConf.package/BaselineOfZeroConf.class/instance/baseline..st
+++ b/mc/BaselineOfZeroConf.package/BaselineOfZeroConf.class/instance/baseline..st
@@ -1,17 +1,13 @@
 accessing
-baseline: spec
+"protocol: accessing"
+baseline: spec 
 	<baseline>
-	spec
-		for: #pharo
-		do: [
-			spec
-				project: 'CommandShell'
-				with: [
-					spec
-						className: 'ConfigurationOfCommandShell';
-						version: #stable;
-						repository: 'http://www.squeaksource.com/MetacelloRepository' ].
-			spec package: 'ZeroConf'.
-			spec package: 'ZeroConf-Tests' with: [ spec requires: #('CommandShell') ].
-			spec group: 'all' with: #('ZeroConf' 'ZeroConf-Tests').
-			spec group: 'default' with: #('ZeroConf') ]
+	
+	spec for: #pharo do: [
+		self commandShell: spec.
+		
+		spec package: 'ZeroConf'.
+		spec package: 'ZeroConf-Tests' with: [ spec requires: #('CommandShell') ].
+		
+		spec group: 'all' with: #('ZeroConf' 'ZeroConf-Tests').
+		spec group: 'default' with: #('ZeroConf') ]	

--- a/mc/BaselineOfZeroConf.package/BaselineOfZeroConf.class/instance/baseline..st
+++ b/mc/BaselineOfZeroConf.package/BaselineOfZeroConf.class/instance/baseline..st
@@ -1,14 +1,17 @@
 accessing
-baseline: spec 
+baseline: spec
 	<baseline>
-	
-	spec for: #pharo do: [
-		spec repository: 'filetree://repository/mc'. 
-		
-		self commandShell: spec.
-		
-		spec package: 'ZeroConf'.
-		spec package: 'ZeroConf-Tests' with: [ spec requires: #('CommandShell') ].
-		
-		spec group: 'all' with: #('ZeroConf' 'ZeroConf-Tests').
-		spec group: 'default' with: #('ZeroConf') ]	
+	spec
+		for: #pharo
+		do: [
+			spec
+				project: 'CommandShell'
+				with: [
+					spec
+						className: 'ConfigurationOfCommandShell';
+						version: #stable;
+						repository: 'http://www.squeaksource.com/MetacelloRepository' ].
+			spec package: 'ZeroConf'.
+			spec package: 'ZeroConf-Tests' with: [ spec requires: #('CommandShell') ].
+			spec group: 'all' with: #('ZeroConf' 'ZeroConf-Tests').
+			spec group: 'default' with: #('ZeroConf') ]

--- a/mc/BaselineOfZeroConf.package/BaselineOfZeroConf.class/instance/commandShell..st
+++ b/mc/BaselineOfZeroConf.package/BaselineOfZeroConf.class/instance/commandShell..st
@@ -1,7 +1,0 @@
-accessing
-commandShell: spec
-	spec project: 'CommandShell' with: [
-		spec
-			className: 'ConfigurationOfCommandShell';
-			version: #stable;
-			repository: 'http://www.squeaksource.com/MetacelloRepository' ].

--- a/mc/BaselineOfZeroConf.package/BaselineOfZeroConf.class/instance/commandShell..st
+++ b/mc/BaselineOfZeroConf.package/BaselineOfZeroConf.class/instance/commandShell..st
@@ -1,0 +1,7 @@
+accessing
+commandShell: spec
+	spec project: 'CommandShell' with: [
+		spec
+			className: 'ConfigurationOfCommandShell';
+			version: #stable;
+			repository: 'http://www.squeaksource.com/MetacelloRepository' ].

--- a/mc/BaselineOfZeroConf.package/BaselineOfZeroConf.class/methodProperties.json
+++ b/mc/BaselineOfZeroConf.package/BaselineOfZeroConf.class/methodProperties.json
@@ -2,5 +2,4 @@
 	"class" : {
 		"load" : "EstebanLorenzano 4/24/2014 16:43:43" },
 	"instance" : {
-		"baseline:" : "PeterUhnak 5/24/2016 18:06",
-		"commandShell:" : "EstebanLorenzano 4/24/2014 16:43:43" } }
+		"baseline:" : "PeterUhnak 5/30/2016 19:02" } }

--- a/mc/BaselineOfZeroConf.package/BaselineOfZeroConf.class/methodProperties.json
+++ b/mc/BaselineOfZeroConf.package/BaselineOfZeroConf.class/methodProperties.json
@@ -2,4 +2,5 @@
 	"class" : {
 		"load" : "EstebanLorenzano 4/24/2014 16:43:43" },
 	"instance" : {
-		"baseline:" : "PeterUhnak 5/30/2016 19:02" } }
+		"baseline:" : "PeterUhnak 6/5/2016 15:33",
+		"commandShell:" : "PeterUhnak 6/5/2016 15:32" } }

--- a/mc/BaselineOfZeroConf.package/BaselineOfZeroConf.class/methodProperties.json
+++ b/mc/BaselineOfZeroConf.package/BaselineOfZeroConf.class/methodProperties.json
@@ -2,5 +2,5 @@
 	"class" : {
 		"load" : "EstebanLorenzano 4/24/2014 16:43:43" },
 	"instance" : {
-		"baseline:" : "PeterUhnak 6/5/2016 15:33",
+		"baseline:" : "PeterUhnak 6/5/2016 15:34",
 		"commandShell:" : "PeterUhnak 6/5/2016 15:32" } }

--- a/mc/BaselineOfZeroConf.package/monticello.meta/version
+++ b/mc/BaselineOfZeroConf.package/monticello.meta/version
@@ -1,4 +1,5 @@
-(name 'BaselineOfZeroConf-PeterUhnak.4' message 'Command shell definition in a separate message.' id '35ced14f-1b3d-4e90-82a9-c43b27fbfeb4' date '5 June 2016' time '3:33:58.408612 pm' author 'PeterUhnak' ancestors ((name 'BaselineOfZeroConf-PeterUhnak.3' message 'Don''t set repository.
+(name 'BaselineOfZeroConf-PeterUhnak.5' message 'Extra comment removed.' id 'e94a0e49-2705-44f7-9223-890b16640caf' date '5 June 2016' time '3:34:59.055943 pm' author 'PeterUhnak' ancestors ((name 'BaselineOfZeroConf-PeterUhnak.4' message 'Command shell definition in a separate message.
+' id '843f63a7-1889-54ba-aa04-f5f82937f6c4' date '5 June 2016' time '3:33:58 pm' author 'PeterUhnak' ancestors ((name 'BaselineOfZeroConf-PeterUhnak.3' message 'Don''t set repository.
 ' id '9d18f975-14cd-52e2-8656-68932ccc6a14' date '30 May 2016' time '7:02:45 pm' author 'PeterUhnak' ancestors ((name 'BaselineOfZeroConf-PeterUhnak.2' message 'Updated baseline to only load core by default.
 ' id '24a507ba-d773-5626-a585-a6e9ebd300fa' date '24 May 2016' time '6:06:45 pm' author 'PeterUhnak' ancestors ((name 'BaselineOfZeroConf-EstebanLorenzano.1' message '- package tests splitted
-' id 'cfd94617-883b-5001-b607-ddde3f806b0e' date '24 April 2014' time '4:43:43 pm' author 'EstebanLorenzano' ancestors () stepChildren ())) stepChildren ())) stepChildren ())) stepChildren ())
+' id 'cfd94617-883b-5001-b607-ddde3f806b0e' date '24 April 2014' time '4:43:43 pm' author 'EstebanLorenzano' ancestors () stepChildren ())) stepChildren ())) stepChildren ())) stepChildren ())) stepChildren ())

--- a/mc/BaselineOfZeroConf.package/monticello.meta/version
+++ b/mc/BaselineOfZeroConf.package/monticello.meta/version
@@ -1,2 +1,4 @@
-(name 'BaselineOfZeroConf-PeterUhnak.3' message 'Don''t set repository.' id '7e45ab6a-6c87-4f9b-a1fb-025f431c14e9' date '30 May 2016' time '7:02:29.340877 pm' author 'PeterUhnak' ancestors ((name 'BaselineOfZeroConf-PeterUhnak.2' message 'Updated baseline to only load core by default.
-' id '24a507ba-d773-5626-a585-a6e9ebd300fa' date '24 May 2016' time '6:06:45 pm' author 'PeterUhnak' ancestors () stepChildren ())) stepChildren ())
+(name 'BaselineOfZeroConf-PeterUhnak.4' message 'Command shell definition in a separate message.' id '35ced14f-1b3d-4e90-82a9-c43b27fbfeb4' date '5 June 2016' time '3:33:58.408612 pm' author 'PeterUhnak' ancestors ((name 'BaselineOfZeroConf-PeterUhnak.3' message 'Don''t set repository.
+' id '9d18f975-14cd-52e2-8656-68932ccc6a14' date '30 May 2016' time '7:02:45 pm' author 'PeterUhnak' ancestors ((name 'BaselineOfZeroConf-PeterUhnak.2' message 'Updated baseline to only load core by default.
+' id '24a507ba-d773-5626-a585-a6e9ebd300fa' date '24 May 2016' time '6:06:45 pm' author 'PeterUhnak' ancestors ((name 'BaselineOfZeroConf-EstebanLorenzano.1' message '- package tests splitted
+' id 'cfd94617-883b-5001-b607-ddde3f806b0e' date '24 April 2014' time '4:43:43 pm' author 'EstebanLorenzano' ancestors () stepChildren ())) stepChildren ())) stepChildren ())) stepChildren ())

--- a/mc/BaselineOfZeroConf.package/monticello.meta/version
+++ b/mc/BaselineOfZeroConf.package/monticello.meta/version
@@ -1,2 +1,2 @@
-(name 'BaselineOfZeroConf-PeterUhnak.2' message 'Updated baseline to only load core by default.' id 'a418e62e-2a46-4983-8330-180b1a9112ca' date '24 May 2016' time '6:06:45.27964 pm' author 'PeterUhnak' ancestors ((name 'BaselineOfZeroConf-EstebanLorenzano.1' message '- package tests splitted
-' id 'cfd94617-883b-5001-b607-ddde3f806b0e' date '24 April 2014' time '4:43:43 pm' author 'EstebanLorenzano' ancestors () stepChildren ())) stepChildren ())
+(name 'BaselineOfZeroConf-PeterUhnak.3' message 'Don''t set repository.' id '7e45ab6a-6c87-4f9b-a1fb-025f431c14e9' date '30 May 2016' time '7:02:29.340877 pm' author 'PeterUhnak' ancestors ((name 'BaselineOfZeroConf-PeterUhnak.2' message 'Updated baseline to only load core by default.
+' id '24a507ba-d773-5626-a585-a6e9ebd300fa' date '24 May 2016' time '6:06:45 pm' author 'PeterUhnak' ancestors () stepChildren ())) stepChildren ())


### PR DESCRIPTION
Minor change that removes `spec repository: 'filetree://repository/mc'.`, because this breaks down when the project is loaded from someone else's `ConfigurationOf`.

And merged in the `commandShell` method, because no point in having an extra method.