### PR TITLE
Linux 32-bit library instructions are obsolete

### DIFF
--- a/mc/ZeroConf.package/ZeroConfVMScript.class/instance/generateLinuxScriptTest.st
+++ b/mc/ZeroConf.package/ZeroConfVMScript.class/instance/generateLinuxScriptTest.st
@@ -4,6 +4,6 @@ generateLinuxScriptTest
 		<<== 'TEST VM REQUIREMENTS UNDER LINUX'
 		<< 'if [ "$OS" == "linux" ]; then
 	$PHARO_VM '<< self optionDash <<'help '<< self optionDash <<'vm-display-null &> /dev/null 2>&1 || (\
-		echo "On a 64-bit system? You must install the 32-bit libraries"; \
-		echo ''   Try `sudo aptitude install ia32-libs` or see http://pharo.org/gnu-linux-installation#64-bit-System-Setup for more info'' )
+		echo "On a 64-bit system? You must enable and install the 32-bit libraries"; \
+		echo "   Please see http://pharo.org/gnu-linux-installation for detailed instructions" )
 fi'; cr


### PR DESCRIPTION
Current 32-bit library instructions are obsolete - just point the user to the web site for the latest instructions.