### PR TITLE
Add tab definition

### DIFF
--- a/mc/ZeroConf.package/AbstractZeroConfBashScript.class/instance/tab.st
+++ b/mc/ZeroConf.package/AbstractZeroConfBashScript.class/instance/tab.st
@@ -1,0 +1,3 @@
+stream delegating
+tab
+	outputStream tab


### PR DESCRIPTION
My previous PR broke the build:

https://ci.inria.fr/pharo/view/all/job/Zeroconf-2-Publish/89/console

I naively thought that it implemented the entire character stream protocol. This time I tested the generation with:

```smalltalk
ZeroConfCommandLineHandler new
	commandLine: (CommandLineArguments new);
	generateScripts
```