### PR TITLE
Add comment # for project url

### DIFF
--- a/mc/ZeroConf.package/AbstractZeroConfBashScript.class/instance/generateHtmlHeader.st
+++ b/mc/ZeroConf.package/AbstractZeroConfBashScript.class/instance/generateHtmlHeader.st
@@ -3,5 +3,7 @@ generateHtmlHeader
 	self 
 		<< '#<html><head><!--'; cr;
 		<< '# The line above makes a fake HTML document out of this bash script'; cr; cr;
-		<< '#This zero conf script was generated from the sources found in:'; cr; tab;
+		<< '#This zero conf script was generated from the sources found in:'; cr;
+		<< '#';
+		tab;
 		<< 'https://github.com/pharo-project/pharo-zeroconf'; cr.


### PR DESCRIPTION
Project url comment should be commented, otherwise it produces a

```
https://github.com/pharo-project/pharo-zeroconf no such file or directory error
```

error.

Please test it before integration, I couldn't do it locally and I have no time to check it now.