### PR TITLE
Use -o option with unzip

### DIFF
--- a/mc/ZeroConf.package/ZeroConfVMScript.class/instance/generateDownloadVm.st
+++ b/mc/ZeroConf.package/ZeroConfVMScript.class/instance/generateDownloadVm.st
@@ -11,7 +11,7 @@ echoerr "	$VM_URL"
 mkdir -p $VM_DIR
 $DOWNLOAD_TO$VM_DIR/vm.zip $VM_URL
 
-unzip -q $VM_DIR/vm.zip -d $VM_DIR
+unzip -oq $VM_DIR/vm.zip -d $VM_DIR
 rm -rf $VM_DIR/vm.zip
 
 if [ "$OS" == "win" ]; then


### PR DESCRIPTION
This will override a current vm if there is one because currently in that case it mess up things:

```
Downloading the latest pharoVM:
	http://files.pharo.org/get-files/70/pharo-linux-stable.zip
replace pharo-vm/bin/pharo? [y]es, [n]o, [A]ll, [N]one, [r]ename: new name: replace pharo-vm/lib/pharo/5.0-201805090836/pharo? [y]es, [n]o, [A]ll, [N]one, [r]ename: error:  invalid response [{ENTER}]
replace pharo-vm/lib/pharo/5.0-201805090836/pharo? [y]es, [n]o, [A]ll, [N]one, [r]ename: error:  invalid response [if [ "$OS]
replace pharo-vm/lib/pharo/5.0-201805090836/pharo? [y]es, [n]o, [A]ll, [N]one, [r]ename: error:  invalid response [" == "win]
replace pharo-vm/lib/pharo/5.0-201805090836/pharo? [y]es, [n]o, [A]ll, [N]one, [r]ename: error:  invalid response [" ]; then]
replace pharo-vm/lib/pharo/5.0-201805090836/pharo? [y]es, [n]o, [A]ll, [N]one, [r]ename: error:  invalid response [{ENTER}]
replace pharo-vm/lib/pharo/5.0-201805090836/pharo? [y]es, [n]o, [A]ll, [N]one, [r]ename: error:  invalid response [    PHARO]
replace pharo-vm/lib/pharo/5.0-201805090836/pharo? [y]es, [n]o, [A]ll, [N]one, [r]ename: error:  invalid response [_VM=`find]
replace pharo-vm/lib/pharo/5.0-201805090836/pharo? [y]es, [n]o, [A]ll, [N]one, [r]ename: error:  invalid response [ $VM_DIR ]
replace pharo-vm/lib/pharo/5.0-201805090836/pharo? [y]es, [n]o, [A]ll, [N]one, [r]ename: error:  invalid response [-name ${V]
replace pharo-vm/lib/pharo/5.0-201805090836/pharo? [y]es, [n]o, [A]ll, [N]one, [r]ename: error:  invalid response [M_BINARY_]
replace pharo-vm/lib/pharo/5.0-201805090836/pharo? [y]es, [n]o, [A]ll, [N]one, [r]ename: ++ find bootstrap-cache -name 'Pharo7.0-32bit-*.zip'
```