### PR TITLE
Handle 32-bit architectures as well

### DIFF
--- a/mc/ZeroConf.package/ZeroConfVMScript.class/instance/generateDetectSystemProperties.st
+++ b/mc/ZeroConf.package/ZeroConfVMScript.class/instance/generateDetectSystemProperties.st
@@ -2,7 +2,13 @@ script generation
 generateDetectSystemProperties
 	self 
 		<<== 'DETECT SYSTEM PROPERTIES';
-		<< 'VM_ARCH=`uname -m`'; cr;
+		<< 'vmArchOut="$(uname -m)"'; cr;
+		<< 'case "${vmArchOut}" in'; cr;
+		<< '    x*)         VM_ARCH=x86_64;;'; cr;
+		<< '    i*)         VM_ARCH=x86;;'; cr;
+		<< '    arm*|ARM*)  VM_ARCH="${vmArchOut}";;'; cr;
+		<< '    *)          VM_ARCH="UNKNOWN:${vmArchOut}";;'; cr;
+		<< 'esac'; cr;
 		<< 'unameOut="$(uname -s)"'; cr;
 		<< 'case "${unameOut}" in'; cr;
 		<< '    Linux*)     OSNAME=Linux;;'; cr;


### PR DESCRIPTION
Added a `case` statement that checks for known architecture variants. Will also assign `UNKNOWN` to the variable, similar to the `OSNAME` variable.

Fixes #32