### PR TITLE
Add MSYS to the OS detection script

### DIFF
--- a/mc/ZeroConf/ZeroConfCurrentPlatform.class.st
+++ b/mc/ZeroConf/ZeroConfCurrentPlatform.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #ZeroConfCurrentPlatform,
 	#superclass : #Object,
-	#category : 'ZeroConf'
+	#category : #ZeroConf
 }
 
 { #category : #generation }
@@ -29,14 +29,14 @@ ZeroConfCurrentPlatform >> generateOperatingSystemDetectionOn: aStream [
 
 	aStream <<== 'DETECT SYSTEM PROPERTIES'.
 	self generateArchitectureDetectionOn: aStream.
+
 	aStream cr;
 		<< 'VM_ARCH=${ARCH}'; cr;
 		<< 'unameOut="$(uname -s)"'; cr;
 		<< 'case "${unameOut}" in'; cr;
 		<< '    Linux*)     OSNAME=Linux;;'; cr;
 		<< '    Darwin*)    OSNAME=Darwin;;'; cr;
-		<< '    CYGWIN*)    OSNAME=Windows;;'; cr;
-		<< '    MINGW*)     OSNAME=Windows;;'; cr;
+		<< '    MSYS*|CYGWIN|MINGW*)     OSNAME=Windows;;'; cr;
 		<< '    *)          OSNAME="UNKNOWN:${unameOut}"'; cr;
 		<< 'esac'; cr
 ]


### PR DESCRIPTION
This PR fixes the problem of MSYS is not detected to download the Pharo stable VM from CLI. The problem occurs in Windows 10 with MSYS 64, which is detected as `http://files.pharo.org/get-files/120/pharo-vm-UNKNOWN:MSYS_NT-10.0-21390-x86_64-stable.zip`, and as consequence the download fail.

