### PR TITLE
compatible with FreeBSD amd64 architecture

### DIFF
--- a/mc/ZeroConf/ZeroConfExplicit64BitPlatform.class.st
+++ b/mc/ZeroConf/ZeroConfExplicit64BitPlatform.class.st
@@ -26,7 +26,7 @@ ZeroConfExplicit64BitPlatform >> generateArchitectureDetectionOn: aStream [
 	aStream cr;
 		<<== 'SEARCH FOR THE CORRESPONDING 64bit ARCHITECTURE';
 		<< 'case "${ARCH}" in'; cr;
-		<< '    x86*)    ARCH="x86_64";;'; cr;
-		<< '    *)       OSNAME="UNKNOWN:${ARCH}"'; cr;
+		<< '    x86*|amd64)    ARCH="x86_64";;'; cr;
+		<< '    *)             OSNAME="UNKNOWN:${ARCH}"'; cr;
 		<< 'esac'; cr
 ]


### PR DESCRIPTION
FreeBSD `uname -m` outputs `amd64`.